### PR TITLE
update to infinity replace logic

### DIFF
--- a/code/updml.q
+++ b/code/updml.q
@@ -45,9 +45,9 @@ gs:1_{[gs;k;n;x;y;f;p;t]
 
 // Utilities for functions to be added to the toolkit
 i.infrep:{
- t:i.inftyp[]first string y;
- {[n;x;y;z]@[x;i;:;z@[x;i:where x=y;:;n]]}[t 0]/[x;t 1 2;(min;max)]}
-i.inftyp:{
-  typ:("5";"8";"9";"6";"7";"12";"16";"17";"18");
-  rep:(0N -32767 32767;0N -0w 0w;0n -0w 0w),6#enlist 0N -0W 0W;
-  typ!rep}
+  // Character representing the type
+  typ:.Q.t@abs y;
+  // the relevant null+infs for type
+  t:typ$(0N;-0w;0W);
+  {[n;x;y;z]@[x;i;:;z@[x;i:where x=y;:;n]]}[t 0]/[x;t 1 2;(min;max)]}
+


### PR DESCRIPTION
* Infinity replace fuunctionality had been resulting in an error when passed timestamps.
  ```
  q).automl.run[([]100?.z.p;100?1f;100?1f;`date$100?0);100?2;`normal;`class;::]
  ```
  This was related to the mapping between types and their versions of infinities and nulls. The function is now type agnostic