### PR TITLE
Closing of figures to reduce process memory usage

### DIFF
--- a/code/postproc/utils.q
+++ b/code/postproc/utils.q
@@ -67,7 +67,8 @@ post.i.impactplot:{[im;mdl;dt;fpath]
   ax[`:set_title]"Feature Impact: ",string mdl;
   ax[`:set_ylabel]"Columns";
   ax[`:set_xlabel]"Relative feature impact";
-  plt[`:savefig][fpath[0][`images],sv["_";string(`Impact_Plot;mdl)],".png";`bbox_inches pykw"tight"];}
+  plt[`:savefig][fpath[0][`images],sv["_";string(`Impact_Plot;mdl)],".png";`bbox_inches pykw"tight"];
+  plt[`:close][];}
 
 post.i.displayCM:{[cm;classes;title;cmap;mdl;fpath]
   if[cmap~();cmap:plt`:cm.Blues];
@@ -88,7 +89,8 @@ post.i.displayCM:{[cm;classes;title;cmap;mdl;fpath]
     }[cm;thresh;;]. 'cross[til shape 0;til shape 1];
   plt[`:xlabel]["Predicted Label";`fontsize pykw 12];
   plt[`:ylabel]["Actual label";`fontsize pykw 12];
-  plt[`:savefig][fpath[0][`images],sv["_";string(`Confusion_Matrix;mdl)],".png";`bbox_inches pykw"tight"];}
+  plt[`:savefig][fpath[0][`images],sv["_";string(`Confusion_Matrix;mdl)],".png";`bbox_inches pykw"tight"];
+  plt[`:close][];}
 
 // Utilities for report generation
 


### PR DESCRIPTION
Figure saving functionality had not been explicitly closed, multiple calls to ```plt[`:figure]``` without closing can result in the following error

```
sys:1: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).
```

The addition ``` plt[`:close][] ``` mitigates against this